### PR TITLE
Index - Improve people modal - Support '.' in names

### DIFF
--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -375,7 +375,7 @@
         {%- if cookiecutter.team['people'] %}
         <div class="row">
             {%- for person in cookiecutter.team['people'] %}
-            {%- set modal_name = person['title']|lower|replace(' ', '--') %}
+            {%- set modal_name = person['title']|lower|replace(' ', '_')|replace('.', '') %}
             {%- set modal_key = '{}-modal'.format(modal_name) %}
             <div class="col-6 col-lg-3 mb-4">
                 <div class="card rounded-0">


### PR DESCRIPTION
Having a '.' in your name broke opening a modal. This is due to the name being used to create a unique HTML ID that assists in opening the corresponding modal with a click on the person's profile.

Found with https://github.com/uwhackweek/event-page-2024/pull/40