### PR TITLE
Removing redundancy

### DIFF
--- a/team/j-michelle-hu.yaml
+++ b/team/j-michelle-hu.yaml
@@ -24,5 +24,5 @@
       link: https://www.linkedin.com/in/j-michelle-hu
   user_groups:
     # From https://escience.washington.edu/using-data-science/hackweeks/planning/hackweek-roles
-    - Hackweek Helper
+    - Helper
 


### PR DESCRIPTION
Update role: remove duplicate "Hackweek"