### PR TITLE
People modal improvements

### DIFF
--- a/team/template.yaml
+++ b/team/template.yaml
@@ -4,6 +4,7 @@
   role: YOUR JOB TITLE
   organizations:
     - name: YOUR EMPLOYER
+  pronouns: pronouns
   bio: >
     A FEW SENTENCES ABOUT YOU, MULTIPLE LINES ARE FINE
   expertise:
@@ -21,4 +22,3 @@
     # From https://escience.washington.edu/using-data-science/hackweeks/planning/hackweek-roles
     - ROLE 1
     - ROLE 2
-

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -375,7 +375,7 @@
         {%- if cookiecutter.team['people'] %}
         <div class="row">
             {%- for person in cookiecutter.team['people'] %}
-            {%- set modal_name = person['title']|lower|replace(' ', '_')|replace('.', '') %}
+            {%- set modal_name = 'person-{}'.format(loop.index) %}
             {%- set modal_key = '{}-modal'.format(modal_name) %}
             <div class="col-6 col-lg-3 mb-4">
                 <div class="card rounded-0">

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -452,6 +452,11 @@
                                             <h2 class="name mb-2">
                                                 {{person['title']}}
                                             </h2>
+                                            {%- if 'pronouns' in person %}
+                                            <div class="meta">
+                                                ({{ person['pronouns'] }})
+                                            </div>
+                                            {%- endif %}
                                             <div class="meta">
                                                 {{ person['role'] }}
                                             </div>


### PR DESCRIPTION
* Add support for any characters in people names
* Add option to specify pronouns to show in detail modal

Reason for adding the pronouns to the people modal only is that long names won't render well on the index page if we append the pronouns to their names.

Example modal:
![Screenshot from 2024-06-27 09-20-39](https://github.com/uwhackweek/event-page-2024/assets/178649/1755f869-9a15-4a1d-960c-21800c639f3d)

This should address issues in PR #24